### PR TITLE
Error while using batch size 1 during evaluation

### DIFF
--- a/core/models/curvenet_util.py
+++ b/core/models/curvenet_util.py
@@ -463,7 +463,7 @@ class CurveGrouping(nn.Module):
                                     self.curve_num,
                                     dim=2,
                                     sorted=False)
-        start_index = start_index.squeeze().unsqueeze(2)
+        start_index = start_index.squeeze(1).unsqueeze(2)
 
         curves = self.walk(xyz, x, idx, start_index)  #bs, c, c_n, c_l
         

--- a/core/models/walk.py
+++ b/core/models/walk.py
@@ -104,7 +104,7 @@ class Walk(nn.Module):
                 pre_feature = starting_points.view(bn, self.curve_num, -1, 1).transpose(1,2) # bs * n, c
             else:
                 # dynamic momentum
-                cat_feature = torch.cat((cur_feature.squeeze(), pre_feature.squeeze()),dim=1)
+                cat_feature = torch.cat((cur_feature.squeeze(-1), pre_feature.squeeze(-1)),dim=1)
                 att_feature = F.softmax(self.momentum_mlp(cat_feature),dim=1).view(bn, 1, self.curve_num, 2) # bs, 1, n, 2
                 cat_feature = torch.cat((cur_feature, pre_feature),dim=-1) # bs, c, n, 2
                 


### PR DESCRIPTION
For line no. 466 in curvenet_util.py file:
For batch size 16:
`start_index` -> (16, 1, 100)
after `start_index.squeeze()` -> (16, 100)
For batch size 1:
`start_index` -> (1, 1, 100)
after `start_index.squeeze()` -> (100)
correct `start_index.squeeze(1)` -> (1, 100)

Similar problem with `cur_feature` and `pre_feature` on line no. 107 in walk.py file.

added dimension in squeeze to handle batch size = 1